### PR TITLE
fix(components): base input, input, number input events and add tests

### DIFF
--- a/packages/components/src/Input/BaseInput.tsx
+++ b/packages/components/src/Input/BaseInput.tsx
@@ -1,5 +1,5 @@
-import { forwardRef, InputHTMLAttributes, ReactNode, useEffect, useRef, useState } from 'react';
-import { Sizes, Spacing } from '@interlay/theme';
+import { Sizes } from '@interlay/theme';
+import { FocusEvent, forwardRef, InputHTMLAttributes, ReactNode, useEffect, useRef, useState } from 'react';
 
 import { Field, FieldProps, useFieldProps } from '../Field';
 import { HelperTextProps } from '../HelperText';
@@ -17,30 +17,30 @@ type Props = {
   value?: string | ReadonlyArray<string> | number;
   defaultValue?: string | ReadonlyArray<string> | number;
   size?: Sizes;
-  // TODO: temporary
-  padding?: { top?: Spacing; bottom?: Spacing; left?: Spacing; right?: Spacing };
   isInvalid?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus?: (e: FocusEvent<Element>) => void;
+  onBlur?: (e: FocusEvent<Element>) => void;
+  inputProps: InputHTMLAttributes<HTMLInputElement>;
 };
-
-type NativeAttrs = Omit<InputHTMLAttributes<HTMLInputElement>, keyof Props>;
 
 type InheritAttrs = Omit<
   HelperTextProps &
     Pick<FieldProps, 'label' | 'labelPosition' | 'labelProps' | 'maxWidth' | 'justifyContent' | 'alignItems'>,
-  keyof (Props & NativeAttrs)
+  keyof Props
 >;
-type BaseInputProps = Props & NativeAttrs & InheritAttrs;
+type BaseInputProps = Props & InheritAttrs;
 
 const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(
   (
-    { startAdornment, endAdornment, bottomAdornment, disabled, size = 'medium', isInvalid, padding, ...props },
+    { startAdornment, endAdornment, bottomAdornment, size = 'medium', isInvalid, inputProps, ...props },
     ref
   ): JSX.Element => {
     const endAdornmentRef = useRef<HTMLDivElement>(null);
     const [endAdornmentWidth, setEndAdornmentWidth] = useState(0);
 
-    const { fieldProps, elementProps } = useFieldProps(props);
+    // FIXME: move this into Field
+    const { fieldProps } = useFieldProps(props);
 
     useEffect(() => {
       if (!endAdornmentRef.current || !endAdornment) return;
@@ -58,12 +58,9 @@ const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(
           $adornments={{ bottom: !!bottomAdornment, left: !!startAdornment, right: !!endAdornment }}
           $endAdornmentWidth={endAdornmentWidth}
           $hasError={error}
-          $isDisabled={!!disabled}
-          $padding={padding}
+          $isDisabled={!!inputProps.disabled}
           $size={size}
-          disabled={disabled}
-          type='text'
-          {...elementProps}
+          {...inputProps}
         />
         {bottomAdornment && <Adornment $position='bottom'>{bottomAdornment}</Adornment>}
         {endAdornment && (

--- a/packages/components/src/Input/Input.style.tsx
+++ b/packages/components/src/Input/Input.style.tsx
@@ -1,13 +1,10 @@
 import styled from 'styled-components';
 import { theme } from '@interlay/theme';
-import { Placement, Sizes, Spacing } from '@interlay/theme';
-
-const getSpacing = (padding?: Spacing) => (padding ? theme.spacing[padding] : undefined);
+import { Placement, Sizes } from '@interlay/theme';
 
 type BaseInputProps = {
   $size: Sizes;
   $adornments: { bottom: boolean; left: boolean; right: boolean };
-  $padding?: { top: Spacing; bottom: Spacing; left: Spacing; right: Spacing };
   $isDisabled: boolean;
   $hasError: boolean;
   $endAdornmentWidth: number;
@@ -48,12 +45,11 @@ const StyledBaseInput = styled.input<BaseInputProps>`
     border-color ${theme.transition.duration.duration150}ms ease-in-out,
     box-shadow ${theme.transition.duration.duration150}ms ease-in-out;
 
-  padding-top: ${({ $padding }) => getSpacing($padding?.top) || theme.spacing.spacing2};
-  padding-left: ${({ $adornments, $padding }) =>
-    getSpacing($padding?.left) || ($adornments.left ? theme.input.paddingX.md : theme.spacing.spacing2)};
+  padding-top: ${theme.spacing.spacing2};
+  padding-left: ${({ $adornments }) => ($adornments.left ? theme.input.paddingX.md : theme.spacing.spacing2)};
 
-  padding-right: ${({ $adornments, $endAdornmentWidth, $padding }) => {
-    if (!$adornments.right) return getSpacing($padding?.right) || theme.spacing.spacing2;
+  padding-right: ${({ $adornments, $endAdornmentWidth }) => {
+    if (!$adornments.right) theme.spacing.spacing2;
 
     // MEMO: adding `spacing6` is a hacky solution because
     // the `endAdornmentWidth` does not update width correctly
@@ -62,8 +58,7 @@ const StyledBaseInput = styled.input<BaseInputProps>`
     // the input overlap the adornment.
     return `calc(${$endAdornmentWidth}px + ${theme.spacing.spacing6})`;
   }};
-  padding-bottom: ${({ $adornments, $padding }) =>
-    getSpacing($padding?.bottom) || ($adornments.bottom ? theme.spacing.spacing6 : theme.spacing.spacing2)};
+  padding-bottom: ${({ $adornments }) => ($adornments.bottom ? theme.spacing.spacing6 : theme.spacing.spacing2)};
 
   &:hover:not(:disabled):not(:focus) {
     border: ${(props) => !props.$isDisabled && !props.$hasError && theme.border.focus};

--- a/packages/components/src/Input/Input.tsx
+++ b/packages/components/src/Input/Input.tsx
@@ -8,34 +8,40 @@ import { BaseInput, BaseInputProps } from './BaseInput';
 type Props = {
   value?: string;
   defaultValue?: string;
+  onValueChange?: (value: string) => void;
 };
 
-type InheritAttrs = Omit<
-  BaseInputProps,
-  keyof Props | 'errorMessageProps' | 'descriptionProps' | 'disabled' | 'required' | 'readOnly'
->;
+type InheritAttrs = Omit<BaseInputProps, keyof Props | 'errorMessageProps' | 'descriptionProps' | 'inputProps'>;
 
 type AriaAttrs = Omit<AriaTextFieldOptions<'input'>, (keyof Props & InheritAttrs) | 'onChange'>;
 
 type InputProps = Props & InheritAttrs & AriaAttrs;
 
-const Input = forwardRef<HTMLInputElement, InputProps>(({ onChange, isInvalid, ...props }, ref): JSX.Element => {
-  const inputRef = useDOMRef(ref);
-  const { inputProps, descriptionProps, errorMessageProps, labelProps } = useTextField(
-    { ...props, isInvalid: isInvalid || !!props.errorMessage },
-    inputRef
-  );
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ isInvalid, onValueChange, onChange, ...props }, ref): JSX.Element => {
+    const inputRef = useDOMRef(ref);
+    // We are specifing `validationState` so that when there are errors, `aria-invalid` is set to `true`
+    const { inputProps, descriptionProps, errorMessageProps, labelProps } = useTextField(
+      {
+        ...props,
+        isInvalid: isInvalid || !!props.errorMessage,
+        onChange: onValueChange
+      },
+      inputRef
+    );
 
-  return (
-    <BaseInput
-      ref={inputRef}
-      descriptionProps={descriptionProps}
-      errorMessageProps={errorMessageProps}
-      labelProps={labelProps}
-      {...mergeProps(props, inputProps, { onChange })}
-    />
-  );
-});
+    return (
+      <BaseInput
+        ref={inputRef}
+        descriptionProps={descriptionProps}
+        errorMessageProps={errorMessageProps}
+        inputProps={mergeProps(inputProps, { onChange })}
+        labelProps={labelProps}
+        {...props}
+      />
+    );
+  }
+);
 
 Input.displayName = 'Input';
 

--- a/packages/components/src/Input/__tests__/Input.test.tsx
+++ b/packages/components/src/Input/__tests__/Input.test.tsx
@@ -1,12 +1,13 @@
-import { render } from '@testing-library/react';
-import { createRef } from 'react';
-import { testA11y } from '@interlay/test-utils';
+import { blur, focus, testA11y } from '@interlay/test-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { createRef, useState } from 'react';
 
 import { Input } from '..';
 
 describe('Input', () => {
   it('should render correctly', () => {
-    const wrapper = render(<Input label='label' />);
+    const wrapper = render(<Input label='Name' />);
 
     expect(() => wrapper.unmount()).not.toThrow();
   });
@@ -21,5 +22,102 @@ describe('Input', () => {
 
   it('should pass a11y', async () => {
     await testA11y(<Input label='label' />);
+  });
+
+  it('should render default value', () => {
+    render(<Input defaultValue='John Doe' label='Name' />);
+
+    expect(screen.getByRole('textbox', { name: /Name/i })).toHaveValue('John Doe');
+  });
+
+  it('should control value', async () => {
+    const Component = () => {
+      const [value, setValue] = useState('John');
+
+      const handleValueChange = (value?: string | number) => setValue(value?.toString() || '');
+
+      return <Input label='Name' value={value} onValueChange={handleValueChange} />;
+    };
+
+    render(<Component />);
+
+    const input = screen.getByRole('textbox', { name: /Name/i });
+
+    expect(input).toHaveValue('John');
+
+    userEvent.type(input, 'y');
+
+    await waitFor(() => {
+      expect(input).toHaveValue('Johny');
+    });
+  });
+
+  it('should be disabled', () => {
+    render(<Input isDisabled label='Name' />);
+
+    expect(screen.getByRole('textbox', { name: /Name/i })).toBeDisabled();
+  });
+
+  it('should render description', () => {
+    render(<Input description='Please enter name' label='Name' />);
+
+    expect(screen.getByRole('textbox', { name: /Name/i })).toHaveAccessibleDescription(/please enter name$/i);
+  });
+
+  it('should render error message', () => {
+    render(<Input errorMessage='Please enter name' label='Name' />);
+
+    expect(screen.getByRole('textbox', { name: /Name/i })).toBeInvalid();
+    expect(screen.getByRole('textbox', { name: /Name/i })).toHaveAccessibleDescription(/please enter name$/i);
+  });
+
+  it('should be read only', () => {
+    render(<Input isReadOnly label='Name' />);
+
+    expect(screen.getByRole('textbox', { name: /Name/i })).toHaveAttribute('readonly');
+  });
+
+  it('should be read only', () => {
+    render(<Input isRequired label='Name' />);
+
+    expect(screen.getByRole('textbox', { name: /Name/i })).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('should emit onChange', async () => {
+    const handleChange = jest.fn();
+
+    render(<Input label='Name' onChange={handleChange} />);
+
+    userEvent.type(screen.getByRole('textbox', { name: /Name/i }), 'j');
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should emit onValueChange', async () => {
+    const handleValueChange = jest.fn();
+
+    render(<Input label='Name' onValueChange={handleValueChange} />);
+
+    userEvent.type(screen.getByRole('textbox', { name: /Name/i }), 'j');
+
+    await waitFor(() => {
+      expect(handleValueChange).toHaveBeenCalledTimes(1);
+      expect(handleValueChange).toHaveBeenCalledWith('j');
+    });
+  });
+
+  it('should emit onBlur', async () => {
+    const handleBlur = jest.fn();
+
+    render(<Input label='Name' onBlur={handleBlur} />);
+
+    focus(screen.getByRole('textbox', { name: /Name/i }));
+    blur(screen.getByRole('textbox', { name: /Name/i }));
+
+    await waitFor(() => {
+      expect(handleBlur).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/components/src/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/components/src/NumberInput/__tests__/NumberInput.test.tsx
@@ -1,12 +1,13 @@
-import { render } from '@testing-library/react';
-import { createRef } from 'react';
-import { testA11y } from '@interlay/test-utils';
+import { blur, focus, testA11y } from '@interlay/test-utils';
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { createRef, useState } from 'react';
 
 import { NumberInput } from '..';
 
 describe('NumberInput', () => {
   it('should render correctly', () => {
-    const wrapper = render(<NumberInput label='label' />);
+    const wrapper = render(<NumberInput label='Amount' />);
 
     expect(() => wrapper.unmount()).not.toThrow();
   });
@@ -21,5 +22,151 @@ describe('NumberInput', () => {
 
   it('should pass a11y', async () => {
     await testA11y(<NumberInput label='label' />);
+  });
+
+  it('should be disabled', () => {
+    render(<NumberInput isDisabled label='Amount' />);
+
+    expect(screen.getByRole('textbox', { name: /amount/i })).toBeDisabled();
+  });
+
+  it('should render default value', () => {
+    render(<NumberInput defaultValue='John Doe' label='Amount' />);
+
+    expect(screen.getByRole('textbox', { name: /amount/i })).toHaveValue('John Doe');
+  });
+
+  it('should control value', async () => {
+    const Component = () => {
+      const [value, setValue] = useState('1');
+
+      const handleValueChange = (value?: string | number) => setValue(value?.toString() || '');
+
+      return <NumberInput label='Amount' value={value} onValueChange={handleValueChange} />;
+    };
+
+    render(<Component />);
+
+    const input = screen.getByRole('textbox', { name: /amount/i });
+
+    expect(input).toHaveValue('1');
+
+    userEvent.type(input, '0');
+
+    await waitFor(() => {
+      expect(input).toHaveValue('10');
+    });
+  });
+
+  it('should be disabled', () => {
+    render(<NumberInput isDisabled label='Amount' />);
+
+    expect(screen.getByRole('textbox', { name: /amount/i })).toBeDisabled();
+  });
+
+  it('should render description', () => {
+    render(<NumberInput description='Please enter name' label='Amount' />);
+
+    expect(screen.getByRole('textbox', { name: /amount/i })).toHaveAccessibleDescription(/please enter name$/i);
+  });
+
+  it('should render error message', () => {
+    render(<NumberInput errorMessage='Please enter name' label='Amount' />);
+
+    expect(screen.getByRole('textbox', { name: /amount/i })).toBeInvalid();
+    expect(screen.getByRole('textbox', { name: /amount/i })).toHaveAccessibleDescription(/please enter name$/i);
+  });
+
+  it('should be read only', () => {
+    render(<NumberInput isReadOnly label='Amount' />);
+
+    expect(screen.getByRole('textbox', { name: /amount/i })).toHaveAttribute('readonly');
+  });
+
+  it('should be read only', () => {
+    render(<NumberInput isRequired label='Amount' />);
+
+    expect(screen.getByRole('textbox', { name: /amount/i })).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('should emit onValueChange', async () => {
+    const handleValueChange = jest.fn();
+
+    render(<NumberInput label='Amount' onValueChange={handleValueChange} />);
+
+    userEvent.type(screen.getByRole('textbox', { name: /amount/i }), '1');
+
+    await waitFor(() => {
+      expect(handleValueChange).toHaveBeenCalledTimes(1);
+      expect(handleValueChange).toHaveBeenCalledWith('1');
+    });
+  });
+
+  it('should emit onBlur', async () => {
+    const handleBlur = jest.fn();
+
+    render(<NumberInput label='Amount' onBlur={handleBlur} />);
+
+    focus(screen.getByRole('textbox', { name: /amount/i }));
+    blur(screen.getByRole('textbox', { name: /amount/i }));
+
+    await waitFor(() => {
+      expect(handleBlur).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('inputMode decimal', () => {
+    it('should emit onChange', async () => {
+      const handleChange = jest.fn();
+
+      render(<NumberInput defaultValue='10' inputMode='decimal' label='Amount' onChange={handleChange} />);
+
+      userEvent.type(screen.getByRole('textbox', { name: /amount/i }), '.');
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledTimes(1);
+        expect(screen.getByRole('textbox', { name: /amount/i })).toHaveValue('10.');
+      });
+    });
+
+    it('should not emit onChange', async () => {
+      const handleChange = jest.fn();
+
+      render(<NumberInput defaultValue='10.2' inputMode='decimal' label='Amount' onChange={handleChange} />);
+
+      userEvent.type(screen.getByRole('textbox', { name: /amount/i }), '.,');
+
+      await waitFor(() => {
+        expect(handleChange).not.toHaveBeenCalled();
+        expect(screen.getByRole('textbox', { name: /amount/i })).toHaveValue('10.2');
+      });
+    });
+  });
+
+  describe('inputMode numeric', () => {
+    it('should emit onChange', async () => {
+      const handleChange = jest.fn();
+
+      render(<NumberInput label='Amount' onChange={handleChange} />);
+
+      userEvent.type(screen.getByRole('textbox', { name: /amount/i }), '2');
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should not emit onChange', async () => {
+      const handleChange = jest.fn();
+
+      render(<NumberInput defaultValue='10' inputMode='decimal' label='Amount' onChange={handleChange} />);
+
+      userEvent.type(screen.getByRole('textbox', { name: /amount/i }), '.,');
+
+      await waitFor(() => {
+        expect(handleChange).not.toHaveBeenCalled();
+        expect(screen.getByRole('textbox', { name: /amount/i })).toHaveValue('10');
+      });
+    });
   });
 });

--- a/packages/components/src/utils/input.ts
+++ b/packages/components/src/utils/input.ts
@@ -1,25 +1,3 @@
-import { RefObject } from 'react';
-
-/**
- * @param {RefObject<HTMLInputElement>}  ref - input ref.
- * @param {string | ReadonlyArray<string> | number} value - value to be included in the event
- * @return {void} - Manually emits onChange event
- */
-// TODO: consider moving away from this type of strategy or narrow
-// the usage, because it only works on native events and `onPress`
-const triggerChangeEvent = (
-  ref: RefObject<HTMLInputElement>,
-  value: string | ReadonlyArray<string> | number = ''
-): void => {
-  const setValue = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
-
-  setValue?.call(ref.current, value);
-
-  const e = new Event('input', { bubbles: true });
-
-  ref.current?.dispatchEvent(e);
-};
-
 type HasErrorProps = { errorMessage?: string | string[]; isInvalid?: boolean };
 
 const hasErrorMessage = (errorMessage?: string | string[]): boolean =>
@@ -28,4 +6,4 @@ const hasErrorMessage = (errorMessage?: string | string[]): boolean =>
 const hasError = ({ errorMessage, isInvalid = false }: HasErrorProps): boolean =>
   (errorMessage && hasErrorMessage(errorMessage)) || isInvalid;
 
-export { hasError, triggerChangeEvent };
+export { hasError };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!
-->

## 📝 Description

- Some events were running 2 times such as `onBlur` and `onFocus`. This was because props were being mishandled. The approach was to introduce a `inputProps` prop
- added new event to NumberInput and Input called `onValueChange`. Handy for when you just want to deal with the value and not with the native event prop.
- added tests

## ⛳️ Current behavior (updates)

No behaviour changes

## 🚀 New behavior

No behaviour changes

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information