### PR TITLE
fix(components): select types

### DIFF
--- a/.changeset/heavy-icons-give.md
+++ b/.changeset/heavy-icons-give.md
@@ -1,0 +1,7 @@
+---
+"@interlay/ui": patch
+"@interlay/theme": patch
+---
+
+fix(components): select types
+fix(theme): bob input disable

--- a/packages/components/src/Select/Select.tsx
+++ b/packages/components/src/Select/Select.tsx
@@ -32,7 +32,7 @@ type ModalAttrs = {
   modalProps?: { ref?: React.Ref<HTMLDivElement> } & Omit<SelectModalProps, 'state' | 'isOpen' | 'onClose' | 'id'>;
 };
 
-type ConditionalAttrs = ListboxAttrs | ModalAttrs;
+// type ConditionalAttrs = ListboxAttrs | ModalAttrs;
 
 type InheritAttrs<T = SelectObject> = Omit<
   CollectionBase<T> & Omit<FieldProps, 'children'> & AriaSelectProps<T>,
@@ -41,7 +41,13 @@ type InheritAttrs<T = SelectObject> = Omit<
 
 type NativeAttrs<T = SelectObject> = Omit<React.InputHTMLAttributes<Element>, keyof Props<T> | 'children'>;
 
-type SelectProps<T = SelectObject> = Props<T> & ConditionalAttrs & NativeAttrs<T> & InheritAttrs<T>;
+type CommonProps<T = SelectObject> = Props<T> & NativeAttrs<T> & InheritAttrs<T>;
+
+type ListboxSelectProps<T = SelectObject> = CommonProps<T> & ListboxAttrs;
+
+type ModalSelectProps<T = SelectObject> = CommonProps<T> & ModalAttrs;
+
+type SelectProps<T = SelectObject> = ModalSelectProps<T> | ListboxSelectProps<T>;
 
 // TODO: listbox is not implemented
 const Select = <T extends SelectObject = SelectObject>(
@@ -172,4 +178,4 @@ const _Select = forwardRef(Select) as <T extends SelectObject = SelectObject>(
 Select.displayName = 'Select';
 
 export { _Select as Select };
-export type { SelectProps };
+export type { SelectProps, ListboxSelectProps, ModalSelectProps };

--- a/packages/components/src/Select/index.tsx
+++ b/packages/components/src/Select/index.tsx
@@ -1,4 +1,4 @@
-export type { SelectProps } from './Select';
+export type { SelectProps, ListboxSelectProps, ModalSelectProps } from './Select';
 export { Select } from './Select';
 export type { SelectTriggerProps } from './SelectTrigger';
 export { SelectTrigger } from './SelectTrigger';

--- a/packages/components/src/TokenInput/TokenSelect.tsx
+++ b/packages/components/src/TokenInput/TokenSelect.tsx
@@ -1,6 +1,8 @@
+import { mergeProps } from '@react-aria/utils';
+
 import { CoinIcon } from '../CoinIcon';
 import { Flex } from '../Flex';
-import { Item, Select, SelectProps } from '../Select';
+import { Item, Select, ModalSelectProps } from '../Select';
 import { Span } from '../Text';
 
 import { StyledTicker, StyledTokenSelect } from './TokenInput.style';
@@ -20,14 +22,14 @@ type TokenData = {
   balanceUSD: number;
 };
 
-type TokenSelectProps = Omit<SelectProps<TokenData>, 'children' | 'type'>;
+type TokenSelectProps = Omit<ModalSelectProps<TokenData>, 'children' | 'type'>;
 
-const TokenSelect = (props: TokenSelectProps): JSX.Element => (
+const TokenSelect = ({ modalProps, ...props }: TokenSelectProps): JSX.Element => (
   <Select<TokenData>
     {...props}
     aria-label='select token'
     asSelectTrigger={StyledTokenSelect}
-    modalProps={{ title: 'Select Token' }}
+    modalProps={mergeProps({ title: 'Select Token' }, modalProps)}
     placeholder={<Span>Select Token</Span>}
     renderValue={(item) => <Value data={item.value as TokenData} />}
     type='modal'

--- a/packages/components/src/TokenInput/__tests__/TokenInput.test.tsx
+++ b/packages/components/src/TokenInput/__tests__/TokenInput.test.tsx
@@ -181,7 +181,7 @@ describe('TokenInput', () => {
       { balance: 2, value: 'ETH', balanceUSD: 900 }
     ];
 
-    it('should render correctly', () => {
+    it('should render correctly', async () => {
       const wrapper = render(<TokenInput label='label' selectProps={{ items }} type='selectable' />);
 
       expect(() => wrapper.unmount()).not.toThrow();
@@ -189,6 +189,20 @@ describe('TokenInput', () => {
 
     it('should pass a11y', async () => {
       await testA11y(<TokenInput label='label' selectProps={{ items }} type='selectable' />);
+    });
+
+    it('ref should be forwarded to the modal', async () => {
+      const ref = createRef<HTMLInputElement>();
+
+      render(<TokenInput label='label' selectProps={{ items, modalProps: { ref } }} type='selectable' />);
+
+      userEvent.click(screen.getByRole('button', { name: /select token/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('dialog', { name: /select token/i })).toBeInTheDocument();
+      });
+
+      expect(ref.current).not.toBeNull();
     });
 
     it('should render empty value', () => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!
-->

Closes # <!-- Github issue # here -->

## 📝 Description

- exported the 2 possible type for our select component
- enforced the correct type in our token input component

## ⛳️ Current behavior (updates)

No Changes

## 🚀 New behavior

No Changes

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information